### PR TITLE
Update to VM and installation instructions

### DIFF
--- a/FccVirtualMachine.md
+++ b/FccVirtualMachine.md
@@ -37,7 +37,12 @@ After initialisation, you'll be confronted with the following
 In order to apply a cernvm-online context, use #<PIN> as username
 ```
 
-FIXME: which context should we take?
+For the moment you will have to log in the [CernVM Online](https://cernvm-online.cern.ch) system, go to `Marketplace` and
+select `Experimental` at the bottom. You'll see a couple of contexts, click on the one named `FCC` and click on `pair`.
+The number shown is what you'll need to insert prefixed with `#` in the command prompt of your VM.
+
+This will launch a SLC6 environment with a user `guest` and the password corresponds to the numbers one to four. Make
+sure to change the password.
 
 
 To use the FCC software in the virtual machine follow the usual [tutorial](FccSoftwareGettingStarted.md).

--- a/installing-fcc.md
+++ b/installing-fcc.md
@@ -12,7 +12,7 @@ The packages that are supported for local usage are [fcc-physics](https://github
 
 ## Installing the latest version
 
-Setup a development area:
+### Setup a development area:
 
 ~~~{.sh}
 mkdir FCC
@@ -22,15 +22,52 @@ export FCC=${PWD}
 
 You need to install the **external** dependencies, check the [fcc-physics README](https://github.com/HEP-FCC/fcc-physics#installing-required-software):
 
-- Either you set up as mentioned in the README (and set `CMAKE_PREFIX_PATH` accordingly) or
-- Install all external packages in one directory `$FCC/externals` and do `export externals_prefix=$FCC/externals`
+> Set up as mentioned in the README (and set `CMAKE_PREFIX_PATH` accordingly) and also set the `PYTHIA8_DIR`.
 
-Install the latest version of the standalone FCC packages:
+### Install the latest version of the standalone FCC packages
+
+You can copy the instructions below into a file and (after making it executable) execute it or copy paste them into a bash shell.
+
+> Be sure to have set the `$FCC` environment variable before you execute.
 
 ~~~{.sh}
 cd $FCC # your local development area
-git clone https://github.com/HEP-FCC/fcc-spi
-cd fcc-spi
-python ./build_latest.py $FCC
+# get all the sources
+declare -a repos=("podio" "fcc-edm" "fcc-physics" "heppy")
+for r in "${repos[@]}"
+do
+  git clone https://github.com/HEP-FCC/$r
+done
+mkdir podio/build;mkdir fcc-edm/build;mkdir fcc-physics/build
+mkdir fcc-install
+# create a setup.sh file that you'll have to source every time
+echo export FCCEDM=$FCC/fcc-install;export PODIO=$FCC/fcc-install; export FCCPHYSICS=$FCC/fcc-install > setup.sh
+echo source $FCC/fcc-install/init_fcc_stack.sh >> setup.sh
+curl https://raw.githubusercontent.com/HEP-FCC/fcc-spi/master/init_fcc_stack.sh -o $FCC/fcc-install/init_fcc_stack.sh
+source setup.sh
 ~~~
 
+Now you have all repository sources in your `$FCC` directory. If you do `ls` you should see them. To compile you need to
+go through the list in this order:
+
+1. podio
+2. fcc-edm
+3. fcc-physics
+
+For each of them go into the build directory: `cd $FCC/<name>/build` and do:
+
+~~~{.sh}
+cmake -DCMAKE_INSTALL_PREFIX=$FCC/fcc-install/ ..
+make install
+~~~
+
+If you encounter errors check the README of the corresponding repository.
+
+
+## Using the local installation
+
+The above lines created a setup script `setup.sh` in the folder `$FCC`. To use the software you'll have to source that file.
+Additionally, make sure that the external software is also setup properly. In order to use heppy you need to also source the
+`init.sh` script in the heppy folder.
+
+For more information on usage, check the individual repositories or tutorial pages.


### PR DESCRIPTION
- Add missing info in VM usage
- Installation instructions were referring to scripts that aren't merged, yet
  - Adding instructions that work *now* to have something for the workshop next week