### PR TITLE
[ci] update centos7 docker image url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v2
     - name: Start container
       run: |
-        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg /bin/bash
-    - name: Setup container
-      run: |
-        docker exec CI_container /bin/bash -c ' ln -s /usr/lib64/liblzma.so.5.2.2 /usr/lib64/liblzma.so;\
-        '
-
+        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/centos7:latest /bin/bash
     - name: RunTests
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package;\


### PR DESCRIPTION
Following a change in the TOS, the dockerhub host is no longer available and the image is now hosted on github instead. The symlink to liblzma is now also fixed in the image.