### PR TITLE
Fix output image filenames in ALLEGRO ECAL simulation section

### DIFF
--- a/full-detector-simulations/FCCeeGeneralOverview/FCCeeGeneralOverview.md
+++ b/full-detector-simulations/FCCeeGeneralOverview/FCCeeGeneralOverview.md
@@ -260,8 +260,8 @@ Now let's plot the energy resolution for raw clusters and MVA calibrated cluster
 
 ```bash
 python plot_calo_energy_resolution.py ALLEGRO_sim_digi_reco.root
-ALLEGRO_sim_digi_reco_clusterEnergyResolution.png
-ALLEGRO_sim_digi_reco_calibratedClusterEnergyResolution.png
+display ALLEGRO_sim_digi_reco_clusterEnergyResolution.png
+display ALLEGRO_sim_digi_reco_calibratedClusterEnergyResolution.png
 ```
 
 Look at both distributions to see how the MVA calibration affects the distribution.

--- a/full-detector-simulations/FCCeeGeneralOverview/FCCeeGeneralOverview.md
+++ b/full-detector-simulations/FCCeeGeneralOverview/FCCeeGeneralOverview.md
@@ -260,8 +260,8 @@ Now let's plot the energy resolution for raw clusters and MVA calibrated cluster
 
 ```bash
 python plot_calo_energy_resolution.py ALLEGRO_sim_digi_reco.root
-display electron_gun_10GeV_ALLEGRO_RECO_clusterEnergyResolution.png
-display electron_gun_10GeV_ALLEGRO_RECO_calibratedClusterEnergyResolution.png
+ALLEGRO_sim_digi_reco_clusterEnergyResolution.png
+ALLEGRO_sim_digi_reco_calibratedClusterEnergyResolution.png
 ```
 
 Look at both distributions to see how the MVA calibration affects the distribution.


### PR DESCRIPTION
Corrected the output image filenames for the ALLEGRO ECAL simulation section in FCCeeGeneralOverview.md.
The previous instructions had old filenames which do not match the generated output files:

- Old: electron_gun_10GeV_ALLEGRO_RECO_clusterEnergyResolution.png
- New: ALLEGRO_sim_digi_reco_clusterEnergyResolution.png

- Old: electron_gun_10GeV_ALLEGRO_RECO_calibratedClusterEnergyResolution.png
- New: ALLEGRO_sim_digi_reco_calibratedClusterEnergyResolution.png

This change aligns the tutorial with the actual output of the simulation.
